### PR TITLE
Build Console Command Add

### DIFF
--- a/iio/app/console/build.sh
+++ b/iio/app/console/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# -- Get the Build Type :
+TYPE=$1
+
+# -- Run Style Parser:
+bash run.sh parse-styles;
+
+if [ "$TYPE" == "all" ]; then
+
+  # -- Run Application Build Parser:
+  bash run.sh build-app sync;
+
+fi;


### PR DESCRIPTION
This console command allows the user to specify if they want to just build the CSS from the components or both the CSS and the HTML build in one roll-through.